### PR TITLE
added support for newer pyyaml versions

### DIFF
--- a/bin/annex-convert
+++ b/bin/annex-convert
@@ -29,7 +29,7 @@ if os.path.exists(custom_objects_filename):
 with open(args.infile, 'r') as inf:
     src = inf.read()
 
-parsed = yaml.load(src)
+parsed = yaml.load(src, Loader=yaml.Loader)
 
 with open(args.outfile, 'w') as outf:
     t = TikzPicture(parsed)


### PR DESCRIPTION
newer pyyaml versions need the Loader=yaml.Loader argument in yaml.load
otherwise annex-convert will crash seeing e.g. !Protocol and not finding the corresponfing python class