### PR TITLE
Multiline captions

### DIFF
--- a/annexlang/components.py
+++ b/annexlang/components.py
@@ -86,7 +86,10 @@ class ProtocolStep(ProtocolObject):
             return text
         if not text:
             return ''
-        return r"\contour{white}{%s}" % text
+        contoured = r"\contour{white}{%s}" % text
+        # we can't have line breaks inside \contour, so we need a new contour command for each line
+        contoured = contoured.replace(r"\\", r"}\\\contour{white}{")
+        return contoured
 
     @cached_property
     def tikz_extra_style(self):

--- a/annexlang/styles.py
+++ b/annexlang/styles.py
@@ -20,7 +20,7 @@ class StyleDefault(yaml.YAMLObject):
     annex_group_title_placeholder/.style={},
     annex_condensed_box/.style={draw=blue,rounded corners=1ex,inner sep=0},
     % start/end parties
-    annex_start_party_box/.style={fill=white,draw,rounded corners=0.3ex,anchor=center,inner sep=0.5ex,minimum height=1.7em,inner sep=1.5mm},
+    annex_start_party_box/.style={fill=white,draw,rounded corners=0.3ex,anchor=center,minimum height=1.7em,inner sep=1.5mm},
     annex_end_party_box/.style={annex_start_party_box,scale=0.7},
     % individual steps
     annex_http_request/.style={-Latex,line,draw=purple},

--- a/annexlang/styles.py
+++ b/annexlang/styles.py
@@ -8,7 +8,7 @@ class StyleDefault(yaml.YAMLObject):
     yaml_tag = "!style-default"
     style = r"""
     % basics
-    every node/.style={font=\sffamily\tiny},
+    every node/.style={font=\sffamily\tiny, align=center},
     annex_lifeline/.style={draw=black!30},
     annex_matrix_node/.style={},
     annex_matrix_dummy_height/.style={},

--- a/docs/examples/demo.yml
+++ b/docs/examples/demo.yml
@@ -86,7 +86,7 @@ protocol:
          - !http-request-response &get_doc_2
            src: *b1i
            dest: *idp1
-           method: GET
+           method: "GET\\\\Path:"
            url: /.wk/idp-proxy
          - !script-action
            dest: *b1d
@@ -133,7 +133,7 @@ protocol:
         - !postmessage
           dest: *b2i
           src: *b2d
-          body: post message stuff
+          body: post message stuff\\and even more\\post message stuff
         - !postmessage
           body: 42
           dest: *b2d


### PR DESCRIPTION
Allow captions, e.g., on arrows, to span multiple lines (with manual line breaks).

Examples:

![image](https://user-images.githubusercontent.com/42440411/97699620-bba75400-1aaa-11eb-83ec-8d0137c5075f.png)

![image](https://user-images.githubusercontent.com/42440411/97699632-c530bc00-1aaa-11eb-8794-8b0225856084.png)
