### PR TITLE
Allow labels on multisteps (e.g., !Serial)

### DIFF
--- a/annexlang/components.py
+++ b/annexlang/components.py
@@ -184,17 +184,15 @@ class MultiStep(ProtocolStep):
             d.draw()
 
     def _init(self, protocol, counter, skip_number):
-        if self.condense or skip_number:
+        if self.condense:
             self.skip_number = False
-            skip_numbers = True
-        else:
-            skip_numbers = False
+        skip_inner_numbers = getattr(self, "skip_inner_numbers", self.condense)
         super()._init(protocol, counter, skip_number)
         for step in self.steps:
-            step._init(protocol, counter, skip_numbers)
+            step._init(protocol, counter, skip_inner_numbers)
 
     def tikz_markers(self):
-        if not self.condense:
+        if not self.condense and not hasattr(self, "label"):
             return ""
 
         if type(self.condense) is not str:
@@ -204,6 +202,9 @@ class MultiStep(ProtocolStep):
         gid = self.annexid
         out = fr"""\node[annex_condensed_box,{fit_string}]({gid}) {{}}; """
         out += fr"\node[] at ({gid}.{self.condense}) {{{self.tex_id}}};"
+        if hasattr(self, "label"):
+            label_pos = getattr(self, "label_pos", "north east")
+            out += fr"\node[annex_multistep_caption_text,anchor={label_pos}] at ({gid}.{label_pos}) {{{self.label}}};"
         return out
         
     def walk(self):

--- a/annexlang/styles.py
+++ b/annexlang/styles.py
@@ -43,6 +43,7 @@ class StyleDefault(yaml.YAMLObject):
     annex_arrow_text/.style={font=\sffamily\tiny},
     annex_postmessage_text/.style={font=\sffamily\tiny\color{red}},
     annex_comment_text/.style={font=\bfseries},
+    annex_multistep_caption_text/.style={font=\sffamily\tiny\color{blue}}
     """
 
 class StyleDebug(yaml.YAMLObject):

--- a/docs/examples/demo.yml
+++ b/docs/examples/demo.yml
@@ -151,6 +151,8 @@ protocol:
     parameters: $\mathit{offer}$
   - !Serial
     lifeline_style: annex_lifeline_dashed
+    label: "This part is\\\\not optional"
+    label_pos: north west  # Default is north east, any TikZ node anchor name will do (e.g., "90")
     steps:
       - !http-request
         src: *example


### PR DESCRIPTION
This is useful to mark parts of a protocol with some caption, e.g.,
optional parts. 

Note that this contains a breaking change: If `skip_number` of a multistep is true, we no longer set it to false automatically. As we can still explicitly set this property, I don't think this is a problem (I can't even think of a case where this would happen without `condense` being used).