### PR TITLE
Allow parties to have multiple instances on one lifeline

### DIFF
--- a/annexlang/language.py
+++ b/annexlang/language.py
@@ -226,7 +226,13 @@ class EndParty(ProtocolStep):
     def tikz(self):
         pos = self.get_pos(self.party.column, self.line)
         text = self.party.name
-        out = fr"""\node[name={self.node_name},annex_{self.type}_box,{self.party.style}] at ({pos}) {{{text}}};"""
+        out = ""
+        if getattr(self.party, "multiple", False):
+            for c in reversed(range(1, 3)):
+                shift = f"{c*.5}mm"
+                name = self.create_affecting_node_name()
+                out += fr"\node[name={name},annex_{self.type}_box,{self.party.style},yshift={shift},xshift={shift}] at ({pos}) {{{text}}};"
+        out += fr"""\node[name={self.node_name},annex_{self.type}_box,{self.party.style}] at ({pos}) {{{text}}};"""
         return out
 
     @property

--- a/docs/examples/demo.yml
+++ b/docs/examples/demo.yml
@@ -17,6 +17,7 @@ protocol:
     !Party
     name: \faServer\ IdP
     style: server
+    multiple: True
   - &b1i
     !Party
     name: \faFile\ \url{idp.example/}


### PR DESCRIPTION
Just add a property "multiple: True" to a party - its start and end nodes will then resemble a stack of instances.

Examples:
![image](https://user-images.githubusercontent.com/42440411/97880515-8f493d00-1d21-11eb-925e-257108fc4453.png) ![image](https://user-images.githubusercontent.com/42440411/97880567-9ec88600-1d21-11eb-8aa7-8ddc4f6fc172.png)

```yml
- &p3
    !Party
    name: Payment\ Handlers
    multiple: True
```